### PR TITLE
Sppark/Ingonyama NTT

### DIFF
--- a/baby-bear/Cargo.toml
+++ b/baby-bear/Cargo.toml
@@ -11,6 +11,7 @@ nightly-features = []
 p3-dft = { path = "../dft" }
 p3-field = { path = "../field" }
 p3-matrix = { path = "../matrix" }
+p3-maybe-rayon = { path = "../maybe-rayon" }
 p3-mds = { path = "../mds" }
 p3-poseidon2 = { path = "../poseidon2" }
 p3-symmetric = { path = "../symmetric" }
@@ -18,9 +19,15 @@ p3-util = { path = "../util" }
 num-bigint = { version = "0.4.3", default-features = false }
 rand = "0.8.5"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
+
+# Icicle dependencies
 icicle-cuda-runtime = { git = "https://github.com/ingonyama-zk/icicle.git" }
 icicle-core = { git = "https://github.com/ingonyama-zk/icicle.git" }
 icicle-babybear = { git = "https://github.com/ingonyama-zk/icicle.git" }
+
+# Sppark dependencies
+sppark = "~0.1.2"
+babybear-ntt = { git = "https://github.com/winston-h-zhang/babybear-ntt.git" }
 
 [dev-dependencies]
 p3-field-testing = { path = "../field-testing" }

--- a/baby-bear/Cargo.toml
+++ b/baby-bear/Cargo.toml
@@ -8,13 +8,19 @@ license = "MIT OR Apache-2.0"
 nightly-features = []
 
 [dependencies]
+p3-dft = { path = "../dft" }
 p3-field = { path = "../field" }
+p3-matrix = { path = "../matrix" }
 p3-mds = { path = "../mds" }
 p3-poseidon2 = { path = "../poseidon2" }
 p3-symmetric = { path = "../symmetric" }
+p3-util = { path = "../util" }
 num-bigint = { version = "0.4.3", default-features = false }
 rand = "0.8.5"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
+icicle-cuda-runtime = { git = "https://github.com/ingonyama-zk/icicle.git" }
+icicle-core = { git = "https://github.com/ingonyama-zk/icicle.git" }
+icicle-babybear = { git = "https://github.com/ingonyama-zk/icicle.git" }
 
 [dev-dependencies]
 p3-field-testing = { path = "../field-testing" }

--- a/baby-bear/src/dft.rs
+++ b/baby-bear/src/dft.rs
@@ -1,14 +1,14 @@
-
 use alloc::vec::Vec;
 
 use icicle_babybear::field::ScalarField;
-use icicle_core::ntt::{initialize_domain, ntt_inplace, release_domain, FieldImpl, NTTConfig, NTTDir};
+use icicle_core::ntt::{initialize_domain, ntt_inplace, release_domain, NTTConfig, NTTDir};
 use icicle_cuda_runtime::device_context::DeviceContext;
 use icicle_cuda_runtime::memory::HostSlice;
-use p3_dft::{Radix2Dit, Radix2DitParallel, TwoAdicSubgroupDft};
-use p3_field::{AbstractField, Field, TwoAdicField};
+use p3_dft::{Radix2DitParallel, TwoAdicSubgroupDft};
+use p3_field::{AbstractField, PrimeField32, TwoAdicField};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
+use p3_maybe_rayon::prelude::IntoParallelRefIterator;
 use p3_util::log2_strict_usize;
 
 use crate::BabyBear;
@@ -17,60 +17,86 @@ type F = BabyBear;
 
 /// GPU DFT/NTT for BabyBear with Ingonyama
 #[derive(Debug, Default, Clone)]
-pub struct BabyBearGpuDft;
+pub struct BabyBearIcicleDft;
 
-impl BabyBearGpuDft {
-    /// Compute the DFT of each column of `mat`.
-    ///
-    /// NB: The DFT works by packing pairs of `Mersenne31` values into
-    /// a `Mersenne31Complex` and doing a (half-length) DFT on the
-    /// result. In particular, the type of the result elements are in
-    /// the extension field, not the domain field.
-    pub fn dft_batch(mat: RowMajorMatrix<F>) -> RowMajorMatrix<F> {
+impl TwoAdicSubgroupDft<F> for BabyBearIcicleDft {
+    type Evaluations = RowMajorMatrix<F>;
+    fn dft_batch(&self, mat: RowMajorMatrix<F>) -> RowMajorMatrix<F> {
         let ctx = DeviceContext::default();
 
         let h = mat.height();
         let w = mat.width();
         let log_h = log2_strict_usize(h);
-        let plonky3_rou = BabyBear::two_adic_generator(log_h);
+        let root = F::two_adic_generator(log_h);
+
         // To compute FFTs using icicle, we first need to initialize it using plonky3's "two adic generator"
-        initialize_domain(ScalarField::from([plonky3_rou.as_canonical_u32()]), &ctx, false).unwrap();
-
-        let ntt_size = 1 << log_h;
-
-        let mut scalars: Vec<ScalarField> = <ScalarField as FieldImpl>::Config::generate_random(w * ntt_size);
-        let scalars_p3: Vec<BabyBear> = scalars
+        initialize_domain(ScalarField::from([root.as_canonical_u32()]), &ctx, false).unwrap();
+        let mut scalars: Vec<ScalarField> = mat
+            .values
             .iter()
-            .map(|x| BabyBear::from_wrapped_u32(Into::<[u32; 1]>::into(*x)[0]))
+            .map(|x| ScalarField::from([x.as_canonical_u32()]))
             .collect();
-        let matrix_p3 = RowMajorMatrix::new(scalars_p3, w);
+        // let scalars_p3: Vec<BabyBear> = scalars
+        //     .iter()
+        //     .map(|x| BabyBear::from_wrapped_u32(Into::<[u32; 1]>::into(*x)[0]))
+        //     .collect();
+        // let matrix_p3 = RowMajorMatrix::new(scalars_p3, w);
+        // assert_eq!(matrix_p3, mat);
 
         let mut ntt_cfg: NTTConfig<'_, ScalarField> = NTTConfig::default();
         // Next two lines signalize that we want to compute `nrows` FFTs in column-ordered fashion
         ntt_cfg.batch_size = w as i32;
         ntt_cfg.columns_batch = true;
-        ntt_inplace(HostSlice::from_mut_slice(&mut scalars[..]), NTTDir::kForward, &ntt_cfg).unwrap();
+        ntt_inplace(
+            HostSlice::from_mut_slice(&mut scalars[..]),
+            NTTDir::kForward,
+            &ntt_cfg,
+        )
+        .unwrap();
 
-        let result_p3 = Radix2DitParallel.dft_batch(matrix_p3);
-
-        for i in 0..w {
-            for j in 0..ntt_size {
-                assert_eq!(
-                    Into::<[u32; 1]>::into(scalars[i + j * w])[0],
-                    result_p3.inner.values[i + j * w].as_canonical_u32()
-                );
-            }
-        }
+        let result_p3: Vec<BabyBear> = scalars
+            .iter()
+            .map(|x| BabyBear::from_wrapped_u32(Into::<[u32; 1]>::into(*x)[0]))
+            .collect();
+        let matrix_p3 = RowMajorMatrix::new(result_p3, w);
+        // let result_p3_test = Radix2DitParallel.dft_batch(mat);
+        // assert_eq!(matrix_p3, result_p3_test.to_row_major_matrix());
 
         release_domain::<ScalarField>(&ctx).unwrap();
-
+        matrix_p3
     }
+}
 
-    // /// Compute the inverse DFT of each column of `mat`.
-    // ///
-    // /// NB: See comment on `dft_batch()` for information on packing.
-    // pub fn idft_batch<Dft: TwoAdicSubgroupDft<C>>(mat: RowMajorMatrix<C>) -> RowMajorMatrix<F> {
-    //     let dft = Dft::default();
-    //     idft_postprocess(dft.idft_batch(idft_preprocess(mat)))
-    // }
+/// GPU DFT/NTT for BabyBear with Sppark
+#[derive(Debug, Default, Clone)]
+pub struct BabyBearSpparkDft;
+
+const DEFAULT_GPU: usize = 0;
+
+impl TwoAdicSubgroupDft<F> for BabyBearSpparkDft {
+    type Evaluations = RowMajorMatrix<F>;
+    fn dft_batch(&self, mat: RowMajorMatrix<F>) -> RowMajorMatrix<F> {
+        let h = mat.height();
+        let rows: Vec<u32> = mat
+            .clone()
+            .transpose().rows()
+            .into_iter()
+            .map(|row| {
+                let mut row: Vec<u32> = row.map(|x| x.as_canonical_u32()).collect();
+                babybear_ntt::NTT(DEFAULT_GPU, &mut row, sppark::NTTInputOutputOrder::NN);
+                row
+            })
+            .flatten()
+            .collect();
+
+        let result_p3: Vec<BabyBear> = rows
+            .iter()
+            .map(|x| BabyBear::from_wrapped_u32(*x))
+            .collect();
+        let matrix_p3 = RowMajorMatrix::new(result_p3, h).transpose();
+        // let result_p3_test = Radix2DitParallel.dft_batch(mat);
+        // assert_eq!(matrix_p3, result_p3_test.to_row_major_matrix());
+
+        matrix_p3
+    }
 }

--- a/baby-bear/src/dft.rs
+++ b/baby-bear/src/dft.rs
@@ -1,0 +1,76 @@
+
+use alloc::vec::Vec;
+
+use icicle_babybear::field::ScalarField;
+use icicle_core::ntt::{initialize_domain, ntt_inplace, release_domain, FieldImpl, NTTConfig, NTTDir};
+use icicle_cuda_runtime::device_context::DeviceContext;
+use icicle_cuda_runtime::memory::HostSlice;
+use p3_dft::{Radix2Dit, Radix2DitParallel, TwoAdicSubgroupDft};
+use p3_field::{AbstractField, Field, TwoAdicField};
+use p3_matrix::dense::RowMajorMatrix;
+use p3_matrix::Matrix;
+use p3_util::log2_strict_usize;
+
+use crate::BabyBear;
+
+type F = BabyBear;
+
+/// GPU DFT/NTT for BabyBear with Ingonyama
+#[derive(Debug, Default, Clone)]
+pub struct BabyBearGpuDft;
+
+impl BabyBearGpuDft {
+    /// Compute the DFT of each column of `mat`.
+    ///
+    /// NB: The DFT works by packing pairs of `Mersenne31` values into
+    /// a `Mersenne31Complex` and doing a (half-length) DFT on the
+    /// result. In particular, the type of the result elements are in
+    /// the extension field, not the domain field.
+    pub fn dft_batch(mat: RowMajorMatrix<F>) -> RowMajorMatrix<F> {
+        let ctx = DeviceContext::default();
+
+        let h = mat.height();
+        let w = mat.width();
+        let log_h = log2_strict_usize(h);
+        let plonky3_rou = BabyBear::two_adic_generator(log_h);
+        // To compute FFTs using icicle, we first need to initialize it using plonky3's "two adic generator"
+        initialize_domain(ScalarField::from([plonky3_rou.as_canonical_u32()]), &ctx, false).unwrap();
+
+        let ntt_size = 1 << log_h;
+
+        let mut scalars: Vec<ScalarField> = <ScalarField as FieldImpl>::Config::generate_random(w * ntt_size);
+        let scalars_p3: Vec<BabyBear> = scalars
+            .iter()
+            .map(|x| BabyBear::from_wrapped_u32(Into::<[u32; 1]>::into(*x)[0]))
+            .collect();
+        let matrix_p3 = RowMajorMatrix::new(scalars_p3, w);
+
+        let mut ntt_cfg: NTTConfig<'_, ScalarField> = NTTConfig::default();
+        // Next two lines signalize that we want to compute `nrows` FFTs in column-ordered fashion
+        ntt_cfg.batch_size = w as i32;
+        ntt_cfg.columns_batch = true;
+        ntt_inplace(HostSlice::from_mut_slice(&mut scalars[..]), NTTDir::kForward, &ntt_cfg).unwrap();
+
+        let result_p3 = Radix2DitParallel.dft_batch(matrix_p3);
+
+        for i in 0..w {
+            for j in 0..ntt_size {
+                assert_eq!(
+                    Into::<[u32; 1]>::into(scalars[i + j * w])[0],
+                    result_p3.inner.values[i + j * w].as_canonical_u32()
+                );
+            }
+        }
+
+        release_domain::<ScalarField>(&ctx).unwrap();
+
+    }
+
+    // /// Compute the inverse DFT of each column of `mat`.
+    // ///
+    // /// NB: See comment on `dft_batch()` for information on packing.
+    // pub fn idft_batch<Dft: TwoAdicSubgroupDft<C>>(mat: RowMajorMatrix<C>) -> RowMajorMatrix<F> {
+    //     let dft = Dft::default();
+    //     idft_postprocess(dft.idft_batch(idft_preprocess(mat)))
+    // }
+}

--- a/baby-bear/src/lib.rs
+++ b/baby-bear/src/lib.rs
@@ -11,11 +11,13 @@
 extern crate alloc;
 
 mod baby_bear;
+mod dft;
 mod extension;
 mod mds;
 mod poseidon2;
 
 pub use baby_bear::*;
+pub use dft::*;
 pub use mds::*;
 pub use poseidon2::*;
 

--- a/dft/benches/fft.rs
+++ b/dft/benches/fft.rs
@@ -1,7 +1,7 @@
 use std::any::type_name;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use p3_baby_bear::BabyBear;
+use p3_baby_bear::{BabyBear, BabyBearIcicleDft, BabyBearSpparkDft};
 use p3_dft::{Radix2Bowers, Radix2Dit, Radix2DitParallel, TwoAdicSubgroupDft};
 use p3_field::extension::Complex;
 use p3_field::TwoAdicField;
@@ -20,9 +20,11 @@ fn bench_fft(c: &mut Criterion) {
 
     const BATCH_SIZE: usize = 100;
 
-    fft::<BabyBear, Radix2Dit<_>, BATCH_SIZE>(c, log_sizes);
-    fft::<BabyBear, Radix2Bowers, BATCH_SIZE>(c, log_sizes);
-    fft::<BabyBear, Radix2DitParallel, BATCH_SIZE>(c, log_sizes);
+    // fft::<BabyBear, Radix2Dit<_>, BATCH_SIZE>(c, log_sizes);
+    // fft::<BabyBear, Radix2Bowers, BATCH_SIZE>(c, log_sizes);
+    // fft::<BabyBear, Radix2DitParallel, BATCH_SIZE>(c, log_sizes);
+    fft::<BabyBear, BabyBearIcicleDft, BATCH_SIZE>(c, log_sizes);
+    fft::<BabyBear, BabyBearSpparkDft, BATCH_SIZE>(c, log_sizes);
     fft::<Goldilocks, Radix2Dit<_>, BATCH_SIZE>(c, log_sizes);
     fft::<Goldilocks, Radix2Bowers, BATCH_SIZE>(c, log_sizes);
     fft::<Goldilocks, Radix2DitParallel, BATCH_SIZE>(c, log_sizes);


### PR DESCRIPTION
This PR adds implementations of GPU-based NTTs, specifically those implemented in [`sppark`](https://github.com/supranational/sppark/tree/main) and [Icicle](https://github.com/ingonyama-zk/icicle/tree/d84ffd2679a4cb8f8d1ac2ad2897bc0b95f4eeeb).

Originally, I planned to integrate only the sppark NTT. However, after running into several issues with sppark, I figured I could include the Ingonyama NTT as a working comparison. The PR adds these two implementations under `BabyBearIcicleDft` (which is correct and working) and `BabyBearSpparkDft` (which has some limitations and is also not entirely correct).

Here's the issues with `sppark`:
1. We cannot compute a batch of NTTs. In the `TwoAdicSubgroupDft` trait, the `dft_batch` method is required to be implemented (and all other members can be derived), and it needs to compute a batch of NTTs. If I understand sppark's API correctly, there is currently no way to do this. So instead, we must loop through the columns of the batch and compute the NTT one at a time. This is very inefficient for GPU utilization.
2. Addition comment on batching: `TwoAdicSubgroupDft::dft_batch` assumes that the NTTs are batched by columns, but the representation is in a `RowMajorMatrix`. Thus, any future batched sppark implementation must be able to column-wise NTTs in a row-major array, or else we would have to call `.transpose()` before passing the NTT to sppark. Note, Ingonyama does have options to do this, as indicated by the `ntt_cfg.columns_batch = true;`.
3. Further debugging is required, since I can't get the sppark output to agree with either the Ingonyama/Plonky3 outputs (Ingonyama and Plonky3 do agree). I'm sure this is because of my lack of understanding in some details about the representation of the NTT, but even after brute forcing all the configurations, I still couldn't get outputs to agree.

To run benchmarks, run `cargo criterion --bench fft --workspace dft`. Here's a sample run:
```
fft::<p3_baby_bear::baby_bear::BabyBear, p3_baby_bear::dft::BabyBearIcicleDft, 100>/16384                        
                        time:   [15.247 ms 15.439 ms 15.649 ms]
Benchmarking fft::<p3_baby_bear::baby_bear::BabyBear, p3_baby_bear::dft::BabyBearIcicleDft, 100>/65536: Collecting 10 samples in estimated 7.2801 s (110 iteratio                                                                                                                                                                 fft::<p3_baby_bear::baby_bear::BabyBear, p3_baby_bear::dft::BabyBearIcicleDft, 100>/65536                        
                        time:   [65.115 ms 65.798 ms 66.270 ms]
Benchmarking fft::<p3_baby_bear::baby_bear::BabyBear, p3_baby_bear::dft::BabyBearIcicleDft, 100>/262144: Collecting 10 samples in estimated 5.0881 s (20 iteratio                                                                                                                                                                 fft::<p3_baby_bear::baby_bear::BabyBear, p3_baby_bear::dft::BabyBearIcicleDft, 100>/262144                        
                        time:   [251.77 ms 254.99 ms 258.94 ms]

Benchmarking fft::<p3_baby_bear::baby_bear::BabyBear, p3_baby_bear::dft::BabyBearSpparkDft, 100>/16384: Collecting 10 samples in estimated 5.8716 s (275 iteratio                                                                                                                                                                 fft::<p3_baby_bear::baby_bear::BabyBear, p3_baby_bear::dft::BabyBearSpparkDft, 100>/16384                        
                        time:   [21.335 ms 21.427 ms 21.480 ms]
Benchmarking fft::<p3_baby_bear::baby_bear::BabyBear, p3_baby_bear::dft::BabyBearSpparkDft, 100>/65536: Collecting 10 samples in estimated 9.0361 s (55 iteration                                                                                                                                                                 fft::<p3_baby_bear::baby_bear::BabyBear, p3_baby_bear::dft::BabyBearSpparkDft, 100>/65536                        
                        time:   [165.45 ms 166.33 ms 167.71 ms]
Benchmarking fft::<p3_baby_bear::baby_bear::BabyBear, p3_baby_bear::dft::BabyBearSpparkDft, 100>/262144: Collecting 10 samples in estimated 6.7541 s (10 iteratio                                                                                                                                                                 fft::<p3_baby_bear::baby_bear::BabyBear, p3_baby_bear::dft::BabyBearSpparkDft, 100>/262144                        
                        time:   [669.45 ms 677.05 ms 686.31 ms]

```